### PR TITLE
Update checkbox to take in the events's state instead of the reverse of the db item

### DIFF
--- a/src/pages/docs_quickstart.html
+++ b/src/pages/docs_quickstart.html
@@ -529,7 +529,7 @@
         e.preventDefault()
         userbase.updateItem({ databaseName: 'todos', itemId: items[i].itemId, item: {
           'todo': items[i].item.todo,
-          'complete': !items[i].item.complete
+          'complete': e.currentTarget.checked
         }})
         .catch((e) => document.getElementById('add-todo-error').innerHTML = e)
       }


### PR DESCRIPTION
This fixes a problem in the example where once the todo is checked, you can't uncheck it.