### PR TITLE
Update docs for forgotPassword - remove incorrect 'user'-param in example

### DIFF
--- a/src/pages/docs_sdk_forgot-password.html
+++ b/src/pages/docs_sdk_forgot-password.html
@@ -8,7 +8,7 @@
     <code class="language-javascript">
       userbase.forgotPassword({
         username: 'example-username'
-      }).then((user) => {
+      }).then(() => {
         // email with temporary password sent
       }).catch((e) => console.error(e))
     </code>


### PR DESCRIPTION
Hi,

While I was experimenting with making a **useUserbase()** React hook, I've noticed an error on the documentation about **forgotPassword**.

It states that a user is returned and this is incorrect.
You can check the `resolve()` of `forgotPassword()` here:
[src/userbase-js/src/auth.js#L826](https://github.com/smallbets/userbase/blob/master/src/userbase-js/src/auth.js#L826)
You'll see that nothing is passed. This PR removes the incorrect user parameter.

```diff
userbase.forgotPassword({
  username: 'example-username'
-}).then((user) => {
+}).then(() => {
  // email with temporary password sent
}).catch((e) => console.error(e))
```

Link to documentation: https://userbase.com/docs/sdk/forgot-password/